### PR TITLE
Added links to git hub page and documentation for Rust Workshop #2.

### DIFF
--- a/content/blog/rust-workshop-2/index.md
+++ b/content/blog/rust-workshop-2/index.md
@@ -10,19 +10,17 @@ math = true
 image = "banner.png"
 +++
 
-Our second Rust workshop in Basel. This time it's about fullstack Rust. Writing you backend, and also your frontend in the rust programming language. 
+Our second Rust workshop in Basel. This time it's been about fullstack Rust. Writing your backend, and also your frontend in the rust programming language. 
 
-For this workshop we will use [dioxus](https://dioxuslabs.com/), where you can write your front end completely rust. It also offers UI native for desktop and even for mobile apps.
+For this workshop we used [dioxus](https://dioxuslabs.com/), where you can write your front end completely rust. It also offers UI native for desktop and even for mobile apps.
 
-We are going to build a fullstack web application with you. This will be a guided workshop, where we are going to build a shareable shopping list.
+This time we build a fullstack web application with you. A guide book about the past workshop you can find [here](https://rust-basel.ch/fullstack-rust-workshop/).In the Workshop we build a shareable shopping list together.
 With this sample fullstack application, you can create, share and edit shopping lists with other people (e.g. your family or room mates).
 
-Stay tuned!
+If you dont feel like recoding it yourself, you can also clone the finished Github repository [here](https://github.com/rust-basel/axum-dioxus-shopping-list).
 
-If you like to attend RVSP [here](https://www.meetup.com/rust-basel/events/299933581/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link). As we only have place for 20 people, RSVP early! It will be in the [Markthalle](https://altemarkthalle.ch/) 200 meters from the SBB Basel Train Station.
+If you like to attend future RVSP meetings you can find the them [here](https://www.meetup.com/rust-basel/).
 
-See you there! :)
-
-Best
+See you next time! :)
 
 Roland & Yasin


### PR DESCRIPTION
I added the github page and documentation page as weblinks to the blog. Also i changed the sentences since the event is over to past tense.